### PR TITLE
Add Filament v5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^4.0",
+        "filament/filament": "^4.0 || ^5.0",
         "spatie/laravel-package-tools": "^1.15"
     },
     "require-dev": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
 use Filament\Infolists\InfolistsServiceProvider;
 use Filament\Notifications\NotificationsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
@@ -18,7 +19,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Livewire\LivewireServiceProvider;
 use MartinPetricko\FilamentRestoreOrCreate\FilamentRestoreOrCreateServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -27,7 +27,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'MartinPetricko\\FilamentSentryFeedback\\Database\\Factories\\' . class_basename($modelName) . 'Factory',
+            fn (string $modelName) => 'MartinPetricko\\FilamentRestoreOrCreate\\Database\\Factories\\' . class_basename($modelName) . 'Factory',
         );
     }
 
@@ -35,7 +35,6 @@ class TestCase extends Orchestra
     {
         return [
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             FilamentServiceProvider::class,
@@ -43,6 +42,7 @@ class TestCase extends Orchestra
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
             NotificationsServiceProvider::class,
+            SchemasServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,


### PR DESCRIPTION
## Summary
- Widen `filament/filament` constraint from `^4.0` to `^4.0 || ^5.0`
- Replace removed `BladeCaptureDirectiveServiceProvider` with `SchemasServiceProvider` in test setup (new in Filament v5)
- Fix factory namespace typo (`FilamentSentryFeedback` → `FilamentRestoreOrCreate`)

All existing APIs used by the plugin (`Action`, `KeyValueEntry`, `mountAction`, `FilamentView::hasSpaMode`, etc.) are unchanged in Filament v5, so no source changes were needed.

## Test plan
- [x] `vendor/bin/pest` — 3 passed
- [x] `vendor/bin/phpstan analyse` — no errors